### PR TITLE
Add include guard

### DIFF
--- a/VoiceRecognitionV3.h
+++ b/VoiceRecognitionV3.h
@@ -26,7 +26,10 @@
   * <h2><center>&copy; COPYRIGHT 2013 ELECHOUSE</center></h2>
   ******************************************************************************
   */
-  
+
+#ifndef VOICERECOGNITION_H
+#define VOICERECOGNITION_H
+
 #if ARDUINO >= 100
  #include "Arduino.h"
 #else
@@ -200,3 +203,4 @@ private:
 	static VR*  instance;
 };
 
+#endif  //VOICERECOGNITION_H


### PR DESCRIPTION
This prevents compilation errors caused by multiple `#include` directives for VoiceRecognitionV3.h:
```
In file included from C:\Users\per\AppData\Local\Temp\arduino_modified_sketch_736655\vr_sample_train.ino:30:0:

E:\electronics\arduino\libraries\VoiceRecognitionV3/VoiceRecognitionV3.h:106:7: error: redefinition of 'class VR'

 class VR : public SoftwareSerial{
```