### PR TITLE
ESP32 fix & fixed bad Serial printout in examplefile: vr_sample_train.ino

### DIFF
--- a/VoiceRecognitionV3.h
+++ b/VoiceRecognitionV3.h
@@ -36,7 +36,6 @@
 #include "wiring_private.h"
 
 #include "SoftwareSerial.h"
-#include <avr/pgmspace.h>
 
 #define DEBUG
 

--- a/examples/vr_sample_train/vr_sample_train.ino
+++ b/examples/vr_sample_train/vr_sample_train.ino
@@ -836,8 +836,9 @@ void printCheckRecordAll(uint8_t *buf, int num)
   else{
     Serial.println(F(" record trained."));
   }
+  Serial.println("");
   myVR.writehex(buf, 255);
-  for(int i=0; i<255; i++){
+  for(int i=0; i<=255; i++){
     if(buf[i] == 0xF0){
       continue;
     }


### PR DESCRIPTION
Removed reference to pgmspace.h library which is not used and prevents building Voice library on ESP32